### PR TITLE
Add Icon/Json support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 Elio Struyf
+Copyright (c) 2020 Jamie Maynard
+Parts Copyright (c) 2020 Elio Struyf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/busylight.service
+++ b/busylight.service
@@ -3,7 +3,7 @@ Description=BusyLight
 After=network.target
 
 [Service]
-User=pi
+User=root
 WorkingDirectory=/home/pi/unicorn-busy-server
 ExecStart=python3 server.py
 Restart=always

--- a/icons/dnd.json
+++ b/icons/dnd.json
@@ -1,0 +1,54 @@
+{
+    "name": "dnd",
+    "author": "Jamie Maynard",
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255}
+        ],
+        [
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/0.json
+++ b/icons/mini/0.json
@@ -1,0 +1,172 @@
+{
+    "name": "0",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/1.json
+++ b/icons/mini/1.json
@@ -1,0 +1,163 @@
+{
+    "name": "1",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+			{"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/2.json
+++ b/icons/mini/2.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "2",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -9,24 +9,18 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
@@ -38,15 +32,21 @@
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},

--- a/icons/mini/3.json
+++ b/icons/mini/3.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "3",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -9,41 +9,41 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}

--- a/icons/mini/4.json
+++ b/icons/mini/4.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "4",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -8,19 +8,7 @@
     "pixels": [
         [
             {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
@@ -33,8 +21,20 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
@@ -43,9 +43,9 @@
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [

--- a/icons/mini/5.json
+++ b/icons/mini/5.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "5",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -7,43 +7,43 @@
     },
     "pixels": [
         [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}

--- a/icons/mini/6.json
+++ b/icons/mini/6.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "6",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -9,41 +9,41 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}

--- a/icons/mini/7.json
+++ b/icons/mini/7.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "7",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -7,26 +7,20 @@
     },
     "pixels": [
         [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
@@ -43,8 +37,14 @@
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],

--- a/icons/mini/8.json
+++ b/icons/mini/8.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "8",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -9,41 +9,41 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}

--- a/icons/mini/9.json
+++ b/icons/mini/9.json
@@ -1,5 +1,5 @@
 {
-    "name": "1",
+    "name": "9",
     "author": "Jamie Maynard",
     "size": {
         "height":  8,
@@ -9,41 +9,42 @@
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+            
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": -1, "green": -1, "blue": -1},
-            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0},
-			{"red": 0, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": -1, "green": -1, "blue": -1},
-            {"red": 0, "green": 0, "blue": 0},
-            {"red": 0, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}

--- a/icons/mini/arrow-down.json
+++ b/icons/mini/arrow-down.json
@@ -1,0 +1,164 @@
+{
+    "name": "arrow-down",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/dnd.json
+++ b/icons/mini/dnd.json
@@ -1,73 +1,73 @@
 {
-    "name": "dnd",
+    "name": "1",
     "author": "Jamie Maynard",
     "size": {
-        "height": 17,
+        "height":  17,
         "width": 7
     },
     "pixels": [
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+			{"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 255, "green": 255, "blue": 255},
@@ -97,65 +97,65 @@
             {"red": 255, "green": 255, "blue": 255}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}, 
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
-        ],
-        [
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0}
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
             {"red": 0, "green": 0, "blue": 0}
         ],
         [
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
-            {"red": 255, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0},
             {"red": 0, "green": 0, "blue": 0}
         ]

--- a/icons/mini/dnd.json
+++ b/icons/mini/dnd.json
@@ -1,0 +1,163 @@
+{
+    "name": "dnd",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255}
+        ],
+        [
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255}
+        ],
+        [
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255},
+            {"red": 255, "green": 255, "blue": 255}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}, 
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/exclaim.json
+++ b/icons/mini/exclaim.json
@@ -1,0 +1,164 @@
+{
+    "name": "exclaimation",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/mini/pencil.json
+++ b/icons/mini/pencil.json
@@ -1,0 +1,164 @@
+{
+    "name": "pencil",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 77, "green": 40, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ]
+    ]
+}

--- a/icons/mini/phone.json
+++ b/icons/mini/phone.json
@@ -1,0 +1,163 @@
+{
+    "name": "phone",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 17,
+        "width": 7
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ]
+    ]
+}

--- a/icons/mini/request.json
+++ b/icons/mini/request.json
@@ -1,0 +1,170 @@
+{
+	"json": {
+		"name": "dnd",
+		"author": "Jamie Maynard",
+		"size": {
+				"height":  17,
+				"width": 7
+		},
+		"pixels": [
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1}
+			],
+			[
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1}
+			],
+			[
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255}
+			],
+			[
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255}
+			],
+			[
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255},
+				{"red": 255, "green": 255, "blue": 255}
+			],
+			[
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1}
+			],
+			[
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": -1, "green": -1, "blue": -1},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			],
+			[
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0},
+				{"red": 0, "green": 0, "blue": 0}
+			]
+		]
+	},
+    "red": 255,
+    "green": 0,
+    "blue": 0,
+    "brightness": 0.5,
+    "speed": null
+}

--- a/icons/mini/template-off.json
+++ b/icons/mini/template-off.json
@@ -1,0 +1,170 @@
+{
+	"json": {
+        "name": "All Off",
+        "author": "Jamie Maynard",
+        "size": {
+                "height":  17,
+                "width": 7
+        },
+        "pixels": [
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ]
+        ]
+    },
+    "red": 255,
+    "green": 0,
+    "blue": 0,
+    "brightness": 0.5,
+    "speed": null
+}

--- a/icons/mini/template-on.json
+++ b/icons/mini/template-on.json
@@ -1,0 +1,170 @@
+{
+	"json": {
+        "name": "All On",
+        "author": "Jamie Maynard",
+        "size": {
+                "height":  17,
+                "width": 7
+        },
+        "pixels": [
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1}
+            ]
+        ]
+    },
+    "red": 255,
+    "green": 0,
+    "blue": 0,
+    "brightness": 0,
+    "speed": null
+}

--- a/icons/phat/0.json
+++ b/icons/phat/0.json
@@ -1,0 +1,58 @@
+{
+    "name": "0",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/1.json
+++ b/icons/phat/1.json
@@ -1,0 +1,58 @@
+{
+    "name": "1",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/2.json
+++ b/icons/phat/2.json
@@ -1,0 +1,58 @@
+{
+    "name": "2",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/3.json
+++ b/icons/phat/3.json
@@ -1,0 +1,58 @@
+{
+    "name": "3",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/4.json
+++ b/icons/phat/4.json
@@ -1,0 +1,58 @@
+{
+    "name": "4",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/5.json
+++ b/icons/phat/5.json
@@ -1,0 +1,58 @@
+{
+    "name": "5",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/6.json
+++ b/icons/phat/6.json
@@ -1,0 +1,58 @@
+{
+    "name": "6",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/7.json
+++ b/icons/phat/7.json
@@ -1,0 +1,58 @@
+{
+    "name": "7",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/8.json
+++ b/icons/phat/8.json
@@ -1,0 +1,58 @@
+{
+    "name": "8",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/9.json
+++ b/icons/phat/9.json
@@ -1,0 +1,59 @@
+{
+    "name": "9",
+    "author": "Jamie Maynard",
+    "size": {
+        "height":  8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+            
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/arrow-down.json
+++ b/icons/phat/arrow-down.json
@@ -1,0 +1,58 @@
+{
+    "name": "arrow-down",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 8,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/dnd.json
+++ b/icons/phat/dnd.json
@@ -1,6 +1,10 @@
 {
     "name": "dnd",
     "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
     "pixels": [
         [
             {"red": 0, "green": 0, "blue": 0},

--- a/icons/phat/exclaim.json
+++ b/icons/phat/exclaim.json
@@ -1,0 +1,58 @@
+{
+    "name": "exclaim",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/pencil.json
+++ b/icons/phat/pencil.json
@@ -1,0 +1,58 @@
+{
+    "name": "pencil",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 255, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 204, "green": 153, "blue": 0},
+            {"red": 204, "green": 153, "blue": 0},
+            {"red": 204, "green": 153, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 204, "green": 153, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ]
+    ]
+}

--- a/icons/phat/phone.json
+++ b/icons/phat/phone.json
@@ -1,0 +1,58 @@
+{
+    "name": "phone",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ]
+    ]
+}

--- a/icons/phat/request.json
+++ b/icons/phat/request.json
@@ -1,0 +1,64 @@
+{
+    "json": {
+        "name": "0",
+        "author": "Jamie Maynard",
+        "size": {
+            "height":  8,
+            "width": 4
+        },
+        "pixels": [
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": -1, "green": -1, "blue": -1},
+                {"red": 0, "green": 0, "blue": 0}
+            ],
+            [
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0},
+                {"red": 0, "green": 0, "blue": 0}
+            ]
+        ]
+    },
+    "red": 255,
+    "green": 255,
+    "blue": 0,
+    "speed": null
+}

--- a/icons/phat/template-off.json
+++ b/icons/phat/template-off.json
@@ -1,0 +1,58 @@
+{
+    "name": "template-off",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/icons/phat/template-on.json
+++ b/icons/phat/template-on.json
@@ -1,0 +1,58 @@
+{
+    "name": "arrow-down",
+    "author": "Jamie Maynard",
+    "size": {
+        "height": 7,
+        "width": 4
+    },
+    "pixels": [
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ],
+        [
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1}
+        ],
+        [
+            {"red": 0, "green": 0, "blue": 0},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": -1, "green": -1, "blue": -1},
+            {"red": 0, "green": 0, "blue": 0}
+        ]
+    ]
+}

--- a/server.py
+++ b/server.py
@@ -26,7 +26,7 @@ width, height = unicorn.get_shape()
 
 app = Flask(__name__)
 
-def setColor(r, g, b, brightness, speed) :
+def setColor(icon, r, g, b, brightness, speed) :
 	global crntColors, globalBlue, globalGreen, globalRed
 	globalRed = r
 	globalGreen = g
@@ -34,10 +34,24 @@ def setColor(r, g, b, brightness, speed) :
 
 	if brightness != '' :
 		unicorn.brightness(brightness)
-
-	for y in range(height):
-		for x in range(width):
-			unicorn.set_pixel(x, y, r, g, b)
+	
+	if icon == "dnd":
+		dnd(r, g, b)
+		globalIcon="dnd"
+	elif icon == "phone":
+		phone(r, g, b)
+		globalIcon="phone"
+	elif icon == "pencil":
+		pencil(r, g, b)
+		globalIcon="pencil"
+	elif icon == "exclaim":
+		exclaim(r, g, b)
+		globalIcon="exclaim"
+	else:
+		globalIcon="none"
+		for y in range(height):
+			for x in range(width):
+				unicorn.set_pixel(x, y, r, g, b)
 	unicorn.show()
 
 	if speed != '' :
@@ -45,20 +59,171 @@ def setColor(r, g, b, brightness, speed) :
 		unicorn.clear()
 		crntT = threading.currentThread()
 		while getattr(crntT, "do_run", True) :
-			for y in range(height):
-				for x in range(width):
-					unicorn.set_pixel(x, y, r, g, b)
+			
+			if icon == "dnd":
+				dnd(r, g, b)
+				globalIcon="dnd"
+			elif icon == "phone":
+				phone(r, g, b)
+				globalIcon="phone"
+			elif icon == "pencil":
+				pencil(r, g, b)
+				globalIcon="pencil"
+			elif icon == "exclaim":
+				exclaim(r, g, b)
+				globalIcon="exclaim"
+			else:
+				globalIncon="none"
+				for y in range(height):
+					for x in range(width):
+						unicorn.set_pixel(x, y, r, g, b)
 			unicorn.show()
 			sleep(speed)
 			unicorn.clear()
 			unicorn.show()
 			sleep(speed)
 		
+def dnd(r, g, b):
+	unicorn.set_pixel(0,0,0,0,0)
+	unicorn.set_pixel(0,1,r,g,b)
+	unicorn.set_pixel(0,2,r,g,b)
+	unicorn.set_pixel(0,3,0,0,0)
+	unicorn.set_pixel(1,0,r,g,b)
+	unicorn.set_pixel(1,1,r,g,b)
+	unicorn.set_pixel(1,2,r,g,b)
+	unicorn.set_pixel(1,3,r,g,b)
+	unicorn.set_pixel(2,0,r,g,b)
+	unicorn.set_pixel(2,1,r,g,b)
+	unicorn.set_pixel(2,2,r,g,b)
+	unicorn.set_pixel(2,3,r,g,b)
+	unicorn.set_pixel(3,0,255,255,255)
+	unicorn.set_pixel(3,1,255,255,255)
+	unicorn.set_pixel(3,2,255,255,255)
+	unicorn.set_pixel(3,3,255,255,255)
+	unicorn.set_pixel(4,0,255,255,255)
+	unicorn.set_pixel(4,1,255,255,255)
+	unicorn.set_pixel(4,2,255,255,255)
+	unicorn.set_pixel(4,3,255,255,255)
+	unicorn.set_pixel(5,0,r,g,b)
+	unicorn.set_pixel(5,1,r,g,b)
+	unicorn.set_pixel(5,2,r,g,b)
+	unicorn.set_pixel(5,3,r,g,b)
+	unicorn.set_pixel(6,0,r,g,b)
+	unicorn.set_pixel(6,1,r,g,b)
+	unicorn.set_pixel(6,2,r,g,b)
+	unicorn.set_pixel(6,3,r,g,b)
+	unicorn.set_pixel(7,0,0,0,0)
+	unicorn.set_pixel(7,1,r,g,b)
+	unicorn.set_pixel(7,2,r,g,b)
+	unicorn.set_pixel(7,3,0,0,0)
+
+def phone(r, g, b):
+	unicorn.set_pixel(0,0,0,0,0)
+	unicorn.set_pixel(0,1,0,0,0)
+	unicorn.set_pixel(0,2,r,g,b)
+	unicorn.set_pixel(0,3,r,g,b)
+	unicorn.set_pixel(1,0,0,0,0)
+	unicorn.set_pixel(1,1,r,g,b)
+	unicorn.set_pixel(1,2,r,g,b)
+	unicorn.set_pixel(1,3,r,g,b)
+	unicorn.set_pixel(2,0,r,g,b)
+	unicorn.set_pixel(2,1,r,g,b)
+	unicorn.set_pixel(2,2,r,g,b)
+	unicorn.set_pixel(2,3,r,g,b)
+	unicorn.set_pixel(3,0,r,g,b)
+	unicorn.set_pixel(3,1,r,g,b)
+	unicorn.set_pixel(3,2,0,0,0)
+	unicorn.set_pixel(3,3,0,0,0)
+	unicorn.set_pixel(4,0,r,g,b)
+	unicorn.set_pixel(4,1,r,g,b)
+	unicorn.set_pixel(4,2,0,0,0)
+	unicorn.set_pixel(4,3,0,0,0)
+	unicorn.set_pixel(5,0,r,g,b)
+	unicorn.set_pixel(5,1,r,g,b)
+	unicorn.set_pixel(5,2,r,g,b)
+	unicorn.set_pixel(5,3,r,g,b)
+	unicorn.set_pixel(6,0,0,0,0)
+	unicorn.set_pixel(6,1,r,g,b)
+	unicorn.set_pixel(6,2,r,g,b)
+	unicorn.set_pixel(6,3,r,g,b)
+	unicorn.set_pixel(7,0,0,0,0)
+	unicorn.set_pixel(7,1,0,0,0)
+	unicorn.set_pixel(7,2,r,g,b)
+	unicorn.set_pixel(7,3,r,g,b)
+
+def pencil(r, g, b):
+	unicorn.set_pixel(0,0,255,0,0)
+	unicorn.set_pixel(0,1,255,0,0)
+	unicorn.set_pixel(0,2,255,0,0)
+	unicorn.set_pixel(0,3,0,0,0)
+	unicorn.set_pixel(1,0,r,g,b)
+	unicorn.set_pixel(1,1,r,g,b)
+	unicorn.set_pixel(1,2,r,g,b)
+	unicorn.set_pixel(1,3,0,0,0)
+	unicorn.set_pixel(2,0,r,g,b)
+	unicorn.set_pixel(2,1,r,g,b)
+	unicorn.set_pixel(2,2,r,g,b)
+	unicorn.set_pixel(2,3,0,0,0)
+	unicorn.set_pixel(3,0,r,g,b)
+	unicorn.set_pixel(3,1,r,g,b)
+	unicorn.set_pixel(3,2,r,g,b)
+	unicorn.set_pixel(3,3,0,0,0)
+	unicorn.set_pixel(4,0,r,g,b)
+	unicorn.set_pixel(4,1,r,g,b)
+	unicorn.set_pixel(4,2,r,g,b)
+	unicorn.set_pixel(4,3,0,0,0)
+	unicorn.set_pixel(5,0,204,153,0)
+	unicorn.set_pixel(5,1,204,153,0)
+	unicorn.set_pixel(5,2,204,153,0)
+	unicorn.set_pixel(5,3,0,0,0)
+	unicorn.set_pixel(6,0,0,0,0)
+	unicorn.set_pixel(6,1,204,153,0)
+	unicorn.set_pixel(6,2,0,0,0)
+	unicorn.set_pixel(6,3,0,0,0)
+	unicorn.set_pixel(7,0,0,0,0)
+	unicorn.set_pixel(7,1,r,g,b)
+	unicorn.set_pixel(7,2,r,g,b)
+	unicorn.set_pixel(7,3,r,g,b)
+
+def exclaim(r, g, b):
+	unicorn.set_pixel(0,0,0,0,0)
+	unicorn.set_pixel(0,1,r,g,b)
+	unicorn.set_pixel(0,2,r,g,b)
+	unicorn.set_pixel(0,3,0,0,0)
+	unicorn.set_pixel(1,0,0,0,0)
+	unicorn.set_pixel(1,1,r,g,b)
+	unicorn.set_pixel(1,2,r,g,b)
+	unicorn.set_pixel(1,3,0,0,0)
+	unicorn.set_pixel(2,0,0,0,0)
+	unicorn.set_pixel(2,1,r,g,b)
+	unicorn.set_pixel(2,2,r,g,b)
+	unicorn.set_pixel(2,3,0,0,0)
+	unicorn.set_pixel(3,0,0,0,0)
+	unicorn.set_pixel(3,1,r,g,b)
+	unicorn.set_pixel(3,2,r,g,b)
+	unicorn.set_pixel(3,3,0,0,0)
+	unicorn.set_pixel(4,0,0,0,0)
+	unicorn.set_pixel(4,1,r,g,b)
+	unicorn.set_pixel(4,2,r,g,b)
+	unicorn.set_pixel(4,3,0,0,0)
+	unicorn.set_pixel(5,0,0,0,0)
+	unicorn.set_pixel(5,1,0,0,0)
+	unicorn.set_pixel(5,2,0,0,0)
+	unicorn.set_pixel(5,3,0,0,0)
+	unicorn.set_pixel(6,0,0,0,0)
+	unicorn.set_pixel(6,1,r,g,b)
+	unicorn.set_pixel(6,2,r,g,b)
+	unicorn.set_pixel(6,3,0,0,0)
+	unicorn.set_pixel(7,0,0,0,0)
+	unicorn.set_pixel(7,1,r,g,b)
+	unicorn.set_pixel(7,2,r,g,b)
+	unicorn.set_pixel(7,3,0,0,0)
+
 def switchOn() :
 	red = randint(10, 255)
 	green = randint(10, 255)
 	blue = randint(10, 255)
-	blinkThread = threading.Thread(target=setColor, args=(red, green, blue, '', ''))
+	blinkThread = threading.Thread(target=setColor, args=('', red, green, blue, '', ''))
 	blinkThread.do_run = True
 	blinkThread.start()
 
@@ -71,6 +236,9 @@ def switchOff() :
 		blinkThread.do_run = False
 	unicorn.clear()
 	unicorn.off()
+
+def shutdownPi() :
+        os.system("shutdown /s /t 1")
 
 def setTimestamp() :
 	global globalLastCalled
@@ -94,6 +262,11 @@ def apiOff() :
 	switchOff()
 	setTimestamp()
 	return jsonify({})
+
+@app.route('/api/shutdown', method=['DELETE'])
+def turnOff() :
+        switchOff()
+        shutdownPi()
 
 @app.route('/api/switch', methods=['POST'])
 def apiSwitch() :

--- a/server.py
+++ b/server.py
@@ -300,7 +300,7 @@ def getIcons():
 
 # This method is added for homekit compatibility
 @app.route('/api/switch/hsv', methods=['POST'])
-def apiSwitchHsv() :
+def apiSwitchHsv():
 	global blinkThread, globalLastCalledApi
 	globalLastCalledApi = '/api/switch/hsv'
 	switchOff()
@@ -319,7 +319,7 @@ def apiSwitchHsv() :
 
 # This is the original method for setting the display
 @app.route('/api/switch/rgb', methods=['POST'])
-def apiSwitchRgb() :
+def apiSwitchRgb():
 	global blinkThread, globalLastCalledApi
 	globalLastCalledApi = '/api/switch/rgb'
 	switchOff()
@@ -337,7 +337,7 @@ def apiSwitchRgb() :
 
 # Added this to allow for simple icons/pixel art
 @app.route('/api/switch/icon', methods=['POST'])
-def apiSwitchIcon() :
+def apiSwitchIcon():
 	global blinkThread, globalLastCalledApi
 	globalLastCalledApi = '/api/switch/icon'
 	switchOff()
@@ -361,7 +361,7 @@ def apiSwitchIcon() :
 # can test the raw JSON before you create an icon
 # json file.
 @app.route('/api/switch/json', methods=['POST'])
-def apiSwitchJson() :
+def apiSwitchJson():
         global blinkThread, globalLastCalledApi
         globalLastCalledApi = '/api/switch/json'
         switchOff()
@@ -382,7 +382,7 @@ def apiSwitchJson() :
         return make_response(jsonify())
 
 @app.route('/api/status', methods=['GET'])
-def apiStatus() :
+def apiStatus():
 	global globalBlue, globalGreen, globalRed, globalLastCalled, globalLastCalledApi
 	cpu = CPUTemperature()
 	return jsonify({ 'red': globalRed, 'green': globalGreen, 'blue': globalBlue, 'lastCalled': globalLastCalled, 'cpuTemp': cpu.temperature, 'lastCalledApi': globalLastCalledApi })

--- a/server.py
+++ b/server.py
@@ -103,9 +103,9 @@ def displayRainbow(step, brightness, speed, run = None):
         global crntColors
         hue = 0
         if step is None:
-                step = 10
+                step = 1
         if speed is None:
-                speed is 0.5
+                speed is 0.2
         if brightness is None:
                 brightness = 0.5
         crntT = threading.currentThread()

--- a/server.py
+++ b/server.py
@@ -84,29 +84,29 @@ def setColor(icon, r, g, b, brightness, speed) :
 			sleep(speed)
 		
 def readJson(file, r, g, b):
-	f = open(file, "r")
-	j= json.loads(f.read())
-        globalIcon = j['name']
-        for x in range(len(j['pixels'])):
+    f = open(file, "r")
+    j= json.loads(f.read())
+    globalIcon = j['name']
+    for x in range(len(j['pixels'])):
                 for y in range(len(j['pixels'][x])):
                         pixel = j['pixels'][x][y]
                         if pixel['red'] == -1:
                                 red = r
-                        else
+                        else:
                                 red = pixel['red']
                         if pixel['green'] == -1:
                                 green = g
-                        else
+                        else:
                                 green = pixel['green']
                         if pixel['blue'] == -1:
                                 blue = b
-                        else
+                        else:
                                 blue = pixel['blue']
                         unicorn.set_pixel(x, y, red, green, blue)
 
 def dnd(r, g, b):
-        readJson("icons/dnd.json", r, g, b)
-        
+	readJson("icons/dnd.json", r, g, b)
+		
 def phone(r, g, b):
 	unicorn.set_pixel(0,0,0,0,0)
 	unicorn.set_pixel(0,1,0,0,0)
@@ -228,7 +228,7 @@ def switchOff() :
 	unicorn.off()
 
 def shutdownPi() :
-        os.system("shutdown /s /t 1")
+		os.system("shutdown /s /t 1")
 
 def setTimestamp() :
 	global globalLastCalled
@@ -253,10 +253,10 @@ def apiOff() :
 	setTimestamp()
 	return jsonify({})
 
-@app.route('/api/shutdown', method=['DELETE'])
+@app.route('/api/shutdown', methods=['DELETE'])
 def turnOff() :
-        switchOff()
-        shutdownPi()
+		switchOff()
+		shutdownPi()
 
 @app.route('/api/switch', methods=['POST'])
 def apiSwitch() :
@@ -264,12 +264,13 @@ def apiSwitch() :
 	globalLastCalledApi = '/api/switch'
 	switchOff()
 	content = request.json
+	icon = content.get('icon', '')
 	red = content.get('red', '')
 	green = content.get('green', '')
 	blue = content.get('blue', '')
 	brightness = content.get('brightness', '')
 	speed = content.get('speed', '')
-	blinkThread = threading.Thread(target=setColor, args=(red, green, blue, brightness, speed))
+	blinkThread = threading.Thread(target=setColor, args=(icon, red, green, blue, brightness, speed))
 	blinkThread.do_run = True
 	blinkThread.start()
 	setTimestamp()

--- a/server.py
+++ b/server.py
@@ -35,6 +35,7 @@ class UnicornWrapper:
             self.type = hat
             self.hat.set_layout(unicornhat.PHAT)
             self.hat.brightness(0.5)
+            self.hat.rotation(90)
         elif hat == 'mini':
             self.hat = UnicornHATMini()
             self.type = hat

--- a/server.py
+++ b/server.py
@@ -255,8 +255,6 @@ def setTimestamp() :
 	global globalLastCalled
 	globalLastCalled = datetime.now()
 
-def set
-
 # API Initialization
 @app.route('/api/on', methods=['GET'])
 def apiOn() :
@@ -305,9 +303,9 @@ def apiSwitchHsv():
 	globalLastCalledApi = '/api/switch/hsv'
 	switchOff()
 	content = request.json
-	h = content.get('hue', 180)
-	s = content.get('saturation', 100)
-	v = content.get('value', 100)
+	h = content.get('hue', 180) / 360
+	s = content.get('saturation', 100) /100
+	v = content.get('value', 100) / 100
 	rgb = tuple(round(i * 255) for i in colorsys.hsv_to_rgb(h,s,v))
 	brightness = content.get('brightness', 0.5)
 	speed = content.get('speed', '')

--- a/server.py
+++ b/server.py
@@ -83,40 +83,30 @@ def setColor(icon, r, g, b, brightness, speed) :
 			unicorn.show()
 			sleep(speed)
 		
-def dnd(r, g, b):
-	unicorn.set_pixel(0,0,0,0,0)
-	unicorn.set_pixel(0,1,r,g,b)
-	unicorn.set_pixel(0,2,r,g,b)
-	unicorn.set_pixel(0,3,0,0,0)
-	unicorn.set_pixel(1,0,r,g,b)
-	unicorn.set_pixel(1,1,r,g,b)
-	unicorn.set_pixel(1,2,r,g,b)
-	unicorn.set_pixel(1,3,r,g,b)
-	unicorn.set_pixel(2,0,r,g,b)
-	unicorn.set_pixel(2,1,r,g,b)
-	unicorn.set_pixel(2,2,r,g,b)
-	unicorn.set_pixel(2,3,r,g,b)
-	unicorn.set_pixel(3,0,255,255,255)
-	unicorn.set_pixel(3,1,255,255,255)
-	unicorn.set_pixel(3,2,255,255,255)
-	unicorn.set_pixel(3,3,255,255,255)
-	unicorn.set_pixel(4,0,255,255,255)
-	unicorn.set_pixel(4,1,255,255,255)
-	unicorn.set_pixel(4,2,255,255,255)
-	unicorn.set_pixel(4,3,255,255,255)
-	unicorn.set_pixel(5,0,r,g,b)
-	unicorn.set_pixel(5,1,r,g,b)
-	unicorn.set_pixel(5,2,r,g,b)
-	unicorn.set_pixel(5,3,r,g,b)
-	unicorn.set_pixel(6,0,r,g,b)
-	unicorn.set_pixel(6,1,r,g,b)
-	unicorn.set_pixel(6,2,r,g,b)
-	unicorn.set_pixel(6,3,r,g,b)
-	unicorn.set_pixel(7,0,0,0,0)
-	unicorn.set_pixel(7,1,r,g,b)
-	unicorn.set_pixel(7,2,r,g,b)
-	unicorn.set_pixel(7,3,0,0,0)
+def readJson(file, r, g, b):
+	f = open(file, "r")
+	j= json.loads(f.read())
+        globalIcon = j['name']
+        for x in range(len(j['pixels'])):
+                for y in range(len(j['pixels'][x])):
+                        pixel = j['pixels'][x][y]
+                        if pixel['red'] == -1:
+                                red = r
+                        else
+                                red = pixel['red']
+                        if pixel['green'] == -1:
+                                green = g
+                        else
+                                green = pixel['green']
+                        if pixel['blue'] == -1:
+                                blue = b
+                        else
+                                blue = pixel['blue']
+                        unicorn.set_pixel(x, y, red, green, blue)
 
+def dnd(r, g, b):
+        readJson("icons/dnd.json", r, g, b)
+        
 def phone(r, g, b):
 	unicorn.set_pixel(0,0,0,0,0)
 	unicorn.set_pixel(0,1,0,0,0)

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,2 @@
+python3 ./test.py
 python3 ./server.py

--- a/test.py
+++ b/test.py
@@ -1,87 +1,19 @@
-import time
-import spidev
-import unicornhat
-from unicornhatmini import UnicornHATMini
+from time import sleep
+from unicorn_wrapper import UnicornWrapper
 
-try:
-        spidev.SpiDev(0,0)
-        unicornmini=True
-except FileNotFoundError:
-        unicornmini=False
+print("Starting Unicorn test...")
+unicorn = UnicornWrapper()
 
-class UnicornWrapper:
-    def __init__(self, hat = None):
-        if hat == 'phat':
-            self.hat = unicornhat
-            self.type = hat
-            self.hat.set_layout(unicornhat.PHAT)
-            self.hat.brightness(0.5)
-        elif hat == 'mini':
-            self.hat = UnicornHATMini()
-            self.type = hat
-            self.hat.set_brightness(0.5)
-        else:
-            self.hat = None
-            self.type = 'none'
-        self.brightness = 0.5
-        self.rotation = 0
-    
-    def get_hat(self):
-        return self.hat
-
-    def clear(self):
-        return self.hat.clear()
-
-    def get_shape(self):
-        return self.hat.get_shape()
-
-    def set_all(self, r, g, b):
-        self.hat.set_all(r, g, b)
-
-    def get_brightness(self):
-        if self.type == 'phat':
-            return self.hat.get_brightness()
-        
-        return self.brightness
-    
-    def set_brightness(self, brightness):
-        self.brightness = brightness
-
-        if self.type == 'phat':
-            self.hat.brightness(brightness)
-        elif self.type == 'mini':
-            self.hat.set_brightness(brightness)
-    
-    def set_pixel(self, x, y, r, g, b):
-        self.hat.set_pixel(x, y, r, g, b)
-    
-    def set_rotation(self, r=0):
-        if self.type == 'phat':
-            self.hat.rotation(r)
-        elif self.type == 'mini':
-            self.hat.set_rotation(r)
-        self.rotation = r
-    
-    def get_rotation(self):
-        return self.rotation
-    
-    def show(self):
-        self.hat.show()
-
-if unicornmini:
-        unicorn = UnicornWrapper('mini')
-else:
-        unicorn = UnicornWrapper('phat')
-
-#get the width and height of the hardware
-width, height = unicorn.get_shape()
-
-r=255
-g=0
-b=0
+print("Starting rainbow test (will take 1 minute 12 seconds...")
+hue = 0
+while hue <= 360:
+    unicorn.setColour(RGB = unicorn.hsvIntToRGB(hue,100,100))
+    sleep(0.2)
+    hue = hue + 1
+print("Starting white test (will take 5 seconds...")
+unicorn.setColour(255,255,255)
+sleep(5)
 unicorn.clear()
-for y in range(height):
-    for x in range(width):
-        unicorn.set_pixel(x, y, r, g, b)
 unicorn.show()
-time.sleep(5)
+
+print("Unicorn test complete")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,87 @@
+import time
+import spidev
+import unicornhat
+from unicornhatmini import UnicornHATMini
+
+try:
+        spidev.SpiDev(0,0)
+        unicornmini=True
+except FileNotFoundError:
+        unicornmini=False
+
+class UnicornWrapper:
+    def __init__(self, hat = None):
+        if hat == 'phat':
+            self.hat = unicornhat
+            self.type = hat
+            self.hat.set_layout(unicornhat.PHAT)
+            self.hat.brightness(0.5)
+        elif hat == 'mini':
+            self.hat = UnicornHATMini()
+            self.type = hat
+            self.hat.set_brightness(0.5)
+        else:
+            self.hat = None
+            self.type = 'none'
+        self.brightness = 0.5
+        self.rotation = 0
+    
+    def get_hat(self):
+        return self.hat
+
+    def clear(self):
+        return self.hat.clear()
+
+    def get_shape(self):
+        return self.hat.get_shape()
+
+    def set_all(self, r, g, b):
+        self.hat.set_all(r, g, b)
+
+    def get_brightness(self):
+        if self.type == 'phat':
+            return self.hat.get_brightness()
+        
+        return self.brightness
+    
+    def set_brightness(self, brightness):
+        self.brightness = brightness
+
+        if self.type == 'phat':
+            self.hat.brightness(brightness)
+        elif self.type == 'mini':
+            self.hat.set_brightness(brightness)
+    
+    def set_pixel(self, x, y, r, g, b):
+        self.hat.set_pixel(x, y, r, g, b)
+    
+    def set_rotation(self, r=0):
+        if self.type == 'phat':
+            self.hat.rotation(r)
+        elif self.type == 'mini':
+            self.hat.set_rotation(r)
+        self.rotation = r
+    
+    def get_rotation(self):
+        return self.rotation
+    
+    def show(self):
+        self.hat.show()
+
+if unicornmini:
+        unicorn = UnicornWrapper('mini')
+else:
+        unicorn = UnicornWrapper('phat')
+
+#get the width and height of the hardware
+width, height = unicorn.get_shape()
+
+r=255
+g=0
+b=0
+unicorn.clear()
+for y in range(height):
+    for x in range(width):
+        unicorn.set_pixel(x, y, r, g, b)
+unicorn.show()
+time.sleep(5)

--- a/unicorn_wrapper.py
+++ b/unicorn_wrapper.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+import colorsys
+import spidev
+import unicornhat
+from unicornhatmini import UnicornHATMini
+
+class UnicornWrapper:
+    def __init__(self, hat = None):
+        if hat is None:
+            try:
+                spidev.SpiDev(0,0)
+                hat = 'mini'
+            except FileNotFoundError:
+                hat = 'phat'
+
+        if hat == 'mini':
+            self.hat = UnicornHATMini()
+            self.type = hat
+            self.hat.set_brightness(0.5)
+            self.hat.set_rotation(90)
+        elif hat == 'dummy':
+            self.hat = None
+            self.type = 'none'
+        else:
+            self.hat = unicornhat
+            self.type = hat
+            self.hat.set_layout(unicornhat.PHAT)
+            self.hat.brightness(0.5)
+            self.hat.rotation(90)
+        self.brightness = 0.5
+        self.rotation = 0
+        self.width, self.height = self.hat.get_shape()
+
+    def getType(self):
+        return self.type
+
+    def getHat(self):
+        return self.hat
+
+    def clear(self):
+        return self.hat.clear()
+
+    def getShape(self):
+        return self.hat.get_shape()
+
+    def setAll(self, r, g, b):
+        self.hat.set_all(r, g, b)
+
+    def getBrightness(self):
+        if self.type == 'phat':
+            return self.hat.get_brightness()
+        
+        return self.brightness
+    
+    def setBrightness(self, brightness):
+        self.brightness = brightness
+
+        if self.type == 'phat':
+            self.hat.brightness(brightness)
+        elif self.type == 'mini':
+            self.hat.set_brightness(brightness)
+    
+    def setPixel(self, x, y, r, g, b):
+        self.hat.set_pixel(x, y, r, g, b)
+    
+    def setColour(self, r = None, g = None, b = None, RGB = None):
+        if RGB is not None:
+            r = RGB[0]
+            g = RGB[1]
+            b = RGB[2] 
+        self.hat.clear()
+        for x in range(self.width):
+            for y in range(self.height):
+                self.setPixel(x, y, r, g, b)
+        self.hat.show()
+    
+    def setRotation(self, r=0):
+        if self.type == 'phat':
+            self.hat.rotation(r)
+        elif self.type == 'mini':
+            self.hat.set_rotation(r)
+        self.rotation = r
+    
+    def getRotation(self):
+        return self.rotation
+    
+    def show(self):
+        self.hat.show()
+
+    def off(self):
+        self.hat.clear()
+        self.hat.show()
+    
+    # Colour converstion operations as we only understand RGB
+    def hsvIntToRGB(self, h, s, v):
+        h = h / 360
+        s = s /100
+        v = v / 100
+        return tuple(round(i * 255) for i in colorsys.hsv_to_rgb(h,s,v))
+    
+    def htmlToRGB(self, html):
+        if len(html) is 6:
+            r = int(f"{html[0]}{html[1]}", 16)
+            g = int(f"{html[2]}{html[3]}", 16)
+            b = int(f"{html[4]}{html[5]}", 16)
+        elif len(html) > 6:
+            r = int(f"{html[1]}{html[2]}", 16)
+            g = int(f"{html[3]}{html[4]}", 16)
+            b = int(f"{html[5]}{html[6]}", 16)
+        else:
+            raise Exception("The Hex value is not in the correct format it should RRGGBB or #RRGGBB the same as HTML")
+        return tuple(r,g,b)


### PR DESCRIPTION
OK there is a lot more in here than just adding Icon and JSON support.  There is a new rainbow option, some API changes, the inclusion of HSV support (for homekit)...  The headline feature was Icon support to help the colour blind person in my primary partners house.   To get there I had to add support for a JSON file format which has turned out well.  I've also added support for the Unicorn Mini via a wrapper class which can detect which Unicorn you are using.  This class is reusable and should help anyone wanting to use the Unicorn Phat/Hat/Mini.