### PR TITLE
Changing the runtime user to "root"

### DIFF
--- a/busylight.service
+++ b/busylight.service
@@ -3,7 +3,7 @@ Description=BusyLight
 After=network.target
 
 [Service]
-User=pi
+User=root
 WorkingDirectory=/home/pi/unicorn-busy-server
 ExecStart=python3 server.py
 Restart=always

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask_cors
 gpiozero
 jsmin
+RPi.GPIO


### PR DESCRIPTION
On both a Raspberry pi 4, and a Raspberry pi Zero W, the application will not start at boot unless the `User=root` is set in the service file.

```
pi@raspberrypi:~ $ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
```

Service output:

```
pi@raspberrypi:~ $ sudo systemctl status busylight.service 
● busylight.service - BusyLight
   Loaded: loaded (/etc/systemd/system/busylight.service; enabled; vendor preset: enabled)
   Active: failed (Result: signal) since Mon 2020-09-28 19:33:13 BST; 13s ago
  Process: 673 ExecStart=/usr/bin/python3 server.py (code=killed, signal=SEGV)
 Main PID: 673 (code=killed, signal=SEGV)

Sep 28 19:33:10 raspberrypi systemd[1]: Started BusyLight.
Sep 28 19:33:11 raspberrypi python3[662]: Can't open /dev/mem: Permission denied
Sep 28 19:33:13 raspberrypi systemd[1]: busylight.service: Service RestartSec=100ms expired, scheduling restart.
Sep 28 19:33:13 raspberrypi systemd[1]: busylight.service: Scheduled restart job, restart counter is at 5.
Sep 28 19:33:13 raspberrypi systemd[1]: Stopped BusyLight.
Sep 28 19:33:13 raspberrypi systemd[1]: busylight.service: Start request repeated too quickly.
Sep 28 19:33:13 raspberrypi systemd[1]: busylight.service: Failed with result 'signal'.
Sep 28 19:33:13 raspberrypi systemd[1]: Failed to start BusyLight.
```

* Starting as `pi`

```
pi@raspberrypi:~/unicorn-busy-server $ ./start.sh 
Can't open /dev/mem: Permission denied
Traceback (most recent call last):
  File "./server.py", line 12, in <module>
    from lib.unicorn_wrapper import UnicornWrapper
  File "/home/pi/unicorn-busy-server/lib/unicorn_wrapper.py", line 6, in <module>
    import unicornhat
  File "/usr/local/lib/python3.7/dist-packages/unicornhat.py", line 35, in <module>
    ws2812.begin()
  File "/usr/local/lib/python3.7/dist-packages/rpi_ws281x/rpi_ws281x.py", line 131, in begin
    raise RuntimeError('ws2811_init failed with code {0} ({1})'.format(resp, str_resp))
RuntimeError: ws2811_init failed with code -5 (mmap() failed)
./start.sh: line 1:   692 Segmentation fault      python3 ./server.py
```

As user `root`:

```
pi@raspberrypi:~/unicorn-busy-server $ sudo vi /etc/systemd/system/busylight.service 
pi@raspberrypi:~/unicorn-busy-server $ grep User /etc/systemd/system/busylight.service 
User=root
pi@raspberrypi:~/unicorn-busy-server $ sudo systemctl daemon-reload 
pi@raspberrypi:~/unicorn-busy-server $ sudo systemctl start busylight
pi@raspberrypi:~/unicorn-busy-server $ sudo systemctl status busylight.service 
● busylight.service - BusyLight
   Loaded: loaded (/etc/systemd/system/busylight.service; enabled; vendor preset: enabled)
   Active: active (running) since Mon 2020-09-28 19:35:19 BST; 4s ago
 Main PID: 747 (python3)
   CGroup: /system.slice/busylight.service
           └─747 /usr/bin/python3 server.py

Sep 28 19:35:19 raspberrypi systemd[1]: Started BusyLight.
Sep 28 19:35:23 raspberrypi python3[747]:  * Serving Flask app "server" (lazy loading)
Sep 28 19:35:23 raspberrypi python3[747]:  * Environment: production
Sep 28 19:35:23 raspberrypi python3[747]:    WARNING: This is a development server. Do not use it in a production deployment.
Sep 28 19:35:23 raspberrypi python3[747]:    Use a production WSGI server instead.
Sep 28 19:35:23 raspberrypi python3[747]:  * Debug mode: off
Sep 28 19:35:23 raspberrypi python3[747]:  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```